### PR TITLE
Subscriptions & credits analytics

### DIFF
--- a/src/components/InferenceAnalytics.tsx
+++ b/src/components/InferenceAnalytics.tsx
@@ -1,3 +1,4 @@
+import { ReactNode } from "react";
 import { CallsAnalytics } from "@/components/charts/CallsAnalytics";
 import { TokensAnalytics } from "@/components/charts/TokensAnalytics";
 import { CreditsAnalytics } from "@/components/charts/CreditsAnalytics";
@@ -5,7 +6,8 @@ import { UsersAnalytics } from "@/components/charts/UsersAnalytics";
 import { RequestTypeConfig } from "@/config/requestTypes";
 
 // Stacks the calls / tokens / (optional) credits / (optional) users charts for one request type.
-export function InferenceAnalytics({ type }: { type: RequestTypeConfig }) {
+// `extra` renders additional type-specific charts at the end (e.g. messages-by-plan on chat).
+export function InferenceAnalytics({ type, extra }: { type: RequestTypeConfig; extra?: ReactNode }) {
 	return (
 		<main className="container mx-auto px-4 py-8">
 			<h2 className="text-2xl sm:text-3xl font-bold mb-6">{type.pageTitle}</h2>
@@ -22,6 +24,12 @@ export function InferenceAnalytics({ type }: { type: RequestTypeConfig }) {
 				<>
 					<br />
 					<UsersAnalytics type={type} />
+				</>
+			)}
+			{extra && (
+				<>
+					<br />
+					{extra}
 				</>
 			)}
 		</main>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -13,6 +13,7 @@ import {
 
 const navLinks = [
 	{ to: "/", label: "Dashboard" },
+	{ to: "/subscriptions", label: "Subscriptions" },
 	{ to: "/api", label: "API" },
 	{ to: "/chat", label: "Chat" },
 	{ to: "/liberclaw", label: "LiberClaw" },

--- a/src/components/charts/CreditsConsumptionAnalytics.tsx
+++ b/src/components/charts/CreditsConsumptionAnalytics.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { useDeferredValue, useMemo, useState } from "react";
+import { DateRange } from "react-day-picker";
+import DateRangePicker from "@/components/DateRangePicker";
+import { formatDate } from "@/utils/dates";
+import { getDates, timeframes } from "@/utils/charts";
+import MultiModelChartContainer from "../MultiModelChartContainer";
+import { useCreditsConsumptionQuery } from "@/hooks/useCreditsConsumptionQuery";
+import { groupCreditsConsumptionPerDay } from "@/utils/subscriptions";
+import { formatCredits } from "@/utils/format";
+
+// Credits are only tracked since metering launched.
+const ALL_TIME_START = "2026-06-01";
+
+export function CreditsConsumptionAnalytics() {
+	const [rangeDate, setRangeDate] = useState<DateRange>();
+	const [selectedTimeframe, setSelectedTimeframe] = useState(timeframes[1]);
+	const [selectedCustomDates, setSelectedCustomDates] = useState<boolean>(false);
+
+	const selectedDates = useMemo(() => {
+		if (selectedCustomDates && rangeDate?.from && rangeDate?.to) {
+			return { start_date: formatDate(rangeDate.from), end_date: formatDate(rangeDate.to) };
+		}
+		return getDates(selectedTimeframe.days, ALL_TIME_START);
+	}, [selectedCustomDates, rangeDate, selectedTimeframe.days]);
+
+	const { data: queryData, isLoading, isFetching } = useCreditsConsumptionQuery(selectedDates);
+	const deferred = useDeferredValue(queryData);
+
+	const data = useMemo(() => {
+		if (!deferred) return [];
+		return groupCreditsConsumptionPerDay(deferred.daily, selectedDates);
+	}, [deferred, selectedDates]);
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle>Credits consumption</CardTitle>
+				<CardDescription>Credits ($) consumed per day, split by tier-covered (subscription) vs prepaid balance</CardDescription>
+			</CardHeader>
+			<CardContent className="max-md:px-3">
+				<div className="flex flex-wrap gap-2 mb-4">
+					{timeframes.map((timeframe) => (
+						<Button
+							key={timeframe.label}
+							className="max-md:h-8 max-md:px-3 max-md:text-xs"
+							variant={timeframe.days === selectedTimeframe.days && !selectedCustomDates ? "default" : "outline"}
+							onClick={() => {
+								setSelectedTimeframe(timeframe);
+								setSelectedCustomDates(false);
+							}}
+						>
+							{timeframe.label}
+						</Button>
+					))}
+					<div onClick={() => setSelectedCustomDates(true)}>
+						<DateRangePicker
+							hasCustomDateBeenClicked={selectedCustomDates}
+							rangeDate={rangeDate}
+							setRangeDate={setRangeDate}
+						/>
+					</div>
+				</div>
+				<div className="relative">
+					{isFetching && (
+						<div className="absolute top-2 right-2 z-10">
+							<div className="animate-spin rounded-full h-4 w-4 border-b-2 border-gray-900"></div>
+						</div>
+					)}
+					{!queryData && isLoading ? (
+						<div className="flex justify-center items-center py-8">
+							<p className="text-gray-500">Loading...</p>
+						</div>
+					) : (
+						<MultiModelChartContainer
+							data={data}
+							cards={[
+								{ number: queryData?.total_credits || 0, description: "Total credits", formatter: formatCredits },
+								{ number: queryData?.total_tier_credits || 0, description: "Tier-covered", formatter: formatCredits },
+								{ number: queryData?.total_prepaid_credits || 0, description: "Prepaid", formatter: formatCredits },
+							]}
+						/>
+					)}
+				</div>
+			</CardContent>
+		</Card>
+	);
+}

--- a/src/components/charts/MessagesBySegmentAnalytics.tsx
+++ b/src/components/charts/MessagesBySegmentAnalytics.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { useDeferredValue, useMemo, useState } from "react";
+import { DateRange } from "react-day-picker";
+import DateRangePicker from "@/components/DateRangePicker";
+import { formatDate } from "@/utils/dates";
+import { getDates, timeframes } from "@/utils/charts";
+import MultiModelChartContainer from "../MultiModelChartContainer";
+import { useMessagesBySegmentQuery } from "@/hooks/useMessagesBySegmentQuery";
+import { groupMessagesBySegmentPerDay } from "@/utils/subscriptions";
+import { formatCount } from "@/utils/format";
+
+// Chat messages predate metering, so the series is continuous across the legacy/new boundary.
+const ALL_TIME_START = "2025-10-02";
+
+export function MessagesBySegmentAnalytics() {
+	const [rangeDate, setRangeDate] = useState<DateRange>();
+	const [selectedTimeframe, setSelectedTimeframe] = useState(timeframes[1]);
+	const [selectedCustomDates, setSelectedCustomDates] = useState<boolean>(false);
+
+	const selectedDates = useMemo(() => {
+		if (selectedCustomDates && rangeDate?.from && rangeDate?.to) {
+			return { start_date: formatDate(rangeDate.from), end_date: formatDate(rangeDate.to) };
+		}
+		return getDates(selectedTimeframe.days, ALL_TIME_START);
+	}, [selectedCustomDates, rangeDate, selectedTimeframe.days]);
+
+	const { data: queryData, isLoading, isFetching } = useMessagesBySegmentQuery(selectedDates);
+	const deferred = useDeferredValue(queryData);
+
+	const data = useMemo(() => {
+		if (!deferred) return [];
+		return groupMessagesBySegmentPerDay(deferred.messages, selectedDates);
+	}, [deferred, selectedDates]);
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle>Messages by plan</CardTitle>
+				<CardDescription>Chat messages per day, split by subscription segment (anonymous, free, paid tiers)</CardDescription>
+			</CardHeader>
+			<CardContent className="max-md:px-3">
+				<div className="flex flex-wrap gap-2 mb-4">
+					{timeframes.map((timeframe) => (
+						<Button
+							key={timeframe.label}
+							className="max-md:h-8 max-md:px-3 max-md:text-xs"
+							variant={timeframe.days === selectedTimeframe.days && !selectedCustomDates ? "default" : "outline"}
+							onClick={() => {
+								setSelectedTimeframe(timeframe);
+								setSelectedCustomDates(false);
+							}}
+						>
+							{timeframe.label}
+						</Button>
+					))}
+					<div onClick={() => setSelectedCustomDates(true)}>
+						<DateRangePicker
+							hasCustomDateBeenClicked={selectedCustomDates}
+							rangeDate={rangeDate}
+							setRangeDate={setRangeDate}
+						/>
+					</div>
+				</div>
+				<div className="relative">
+					{isFetching && (
+						<div className="absolute top-2 right-2 z-10">
+							<div className="animate-spin rounded-full h-4 w-4 border-b-2 border-gray-900"></div>
+						</div>
+					)}
+					{!queryData && isLoading ? (
+						<div className="flex justify-center items-center py-8">
+							<p className="text-gray-500">Loading...</p>
+						</div>
+					) : (
+						<MultiModelChartContainer
+							data={data}
+							cards={[
+								{ number: queryData?.total_messages || 0, description: "Total messages", formatter: formatCount },
+							]}
+						/>
+					)}
+				</div>
+			</CardContent>
+		</Card>
+	);
+}

--- a/src/components/charts/SubscribersByTier.tsx
+++ b/src/components/charts/SubscribersByTier.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { useSubscriptionsQuery } from "@/hooks/useSubscriptionsQuery";
+
+const TIER_ORDER = ["go", "plus", "max"];
+const tierLabel = (tier: string) => tier.charAt(0).toUpperCase() + tier.slice(1);
+
+export function SubscribersByTier() {
+	const { data, isLoading } = useSubscriptionsQuery();
+
+	const byTier = [...(data?.subscribers_by_tier ?? [])].sort(
+		(a, b) => (TIER_ORDER.indexOf(a.tier) + 1 || 99) - (TIER_ORDER.indexOf(b.tier) + 1 || 99),
+	);
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle>Active subscribers</CardTitle>
+				<CardDescription>Current paid subscribers per tier (live snapshot)</CardDescription>
+			</CardHeader>
+			<CardContent className="max-md:px-3">
+				{isLoading ? (
+					<div className="flex justify-center items-center py-8">
+						<p className="text-gray-500">Loading...</p>
+					</div>
+				) : (
+					<div className="grid grid-cols-2 md:flex gap-3">
+						<Card className="md:w-fit md:mx-auto">
+							<CardHeader className="text-center py-4">
+								<CardTitle>{data?.total_paid_subscribers ?? 0}</CardTitle>
+								<CardDescription>Total paid</CardDescription>
+							</CardHeader>
+						</Card>
+						{byTier.map((t) => (
+							<Card key={t.tier} className="md:w-fit md:mx-auto">
+								<CardHeader className="text-center py-4">
+									<CardTitle>{t.active_subscribers}</CardTitle>
+									<CardDescription>{tierLabel(t.tier)}</CardDescription>
+								</CardHeader>
+							</Card>
+						))}
+						{byTier.length === 0 && <p className="text-gray-500 py-4">No active paid subscribers yet.</p>}
+					</div>
+				)}
+			</CardContent>
+		</Card>
+	);
+}

--- a/src/components/charts/UsersBySegment.tsx
+++ b/src/components/charts/UsersBySegment.tsx
@@ -4,20 +4,30 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { useSubscriptionsQuery } from "@/hooks/useSubscriptionsQuery";
 
 const TIER_ORDER = ["go", "plus", "max"];
-const tierLabel = (tier: string) => tier.charAt(0).toUpperCase() + tier.slice(1);
+const label = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
 
-export function SubscribersByTier() {
+/** User base by segment (snapshot): anonymous + free + paid tiers. Subscriptions cover all usage,
+ * so this is a users view, not a chat metric. */
+export function UsersBySegment() {
 	const { data, isLoading } = useSubscriptionsQuery();
 
 	const byTier = [...(data?.subscribers_by_tier ?? [])].sort(
 		(a, b) => (TIER_ORDER.indexOf(a.tier) + 1 || 99) - (TIER_ORDER.indexOf(b.tier) + 1 || 99),
 	);
 
+	const cards = [
+		{ key: "anonymous", value: data?.anonymous_users ?? 0, label: "Anonymous" },
+		{ key: "free", value: data?.free_users ?? 0, label: "Free" },
+		...byTier.map((t) => ({ key: t.tier, value: t.active_subscribers, label: label(t.tier) })),
+	];
+
 	return (
 		<Card>
 			<CardHeader>
-				<CardTitle>Active subscribers</CardTitle>
-				<CardDescription>Current paid subscribers per tier (live snapshot)</CardDescription>
+				<CardTitle>Users by segment</CardTitle>
+				<CardDescription>
+					Anonymous (distinct logged-out IPs), registered free users, and active paid subscribers per tier
+				</CardDescription>
 			</CardHeader>
 			<CardContent className="max-md:px-3">
 				{isLoading ? (
@@ -26,21 +36,14 @@ export function SubscribersByTier() {
 					</div>
 				) : (
 					<div className="grid grid-cols-2 md:flex gap-3">
-						<Card className="md:w-fit md:mx-auto">
-							<CardHeader className="text-center py-4">
-								<CardTitle>{data?.total_paid_subscribers ?? 0}</CardTitle>
-								<CardDescription>Total paid</CardDescription>
-							</CardHeader>
-						</Card>
-						{byTier.map((t) => (
-							<Card key={t.tier} className="md:w-fit md:mx-auto">
+						{cards.map((c) => (
+							<Card key={c.key} className="md:w-fit md:mx-auto">
 								<CardHeader className="text-center py-4">
-									<CardTitle>{t.active_subscribers}</CardTitle>
-									<CardDescription>{tierLabel(t.tier)}</CardDescription>
+									<CardTitle>{c.value}</CardTitle>
+									<CardDescription>{c.label}</CardDescription>
 								</CardHeader>
 							</Card>
 						))}
-						{byTier.length === 0 && <p className="text-gray-500 py-4">No active paid subscribers yet.</p>}
 					</div>
 				)}
 			</CardContent>

--- a/src/hooks/useCreditsConsumptionQuery.ts
+++ b/src/hooks/useCreditsConsumptionQuery.ts
@@ -1,0 +1,39 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import { CreditsConsumptionDay, CreditsConsumptionDaySchema } from "@/types/subscriptions";
+import { ChartDate } from "@/types/dates";
+import env from "@/config/env";
+
+type Response = {
+	total_credits: number;
+	total_tier_credits: number;
+	total_prepaid_credits: number;
+	daily: CreditsConsumptionDay[];
+};
+
+async function fetchCreditsConsumption(rangeDate: ChartDate): Promise<Response> {
+	const res = await axios.get(
+		`${env.INFERENCE_BACKEND_URL}/stats/global/credits-consumption?start_date=${rangeDate.start_date}&end_date=${rangeDate.end_date}`,
+	);
+	const daily: CreditsConsumptionDay[] = (res.data["daily"] ?? []).map((d: CreditsConsumptionDay) =>
+		CreditsConsumptionDaySchema.parse(d),
+	);
+	return {
+		total_credits: res.data["total_credits"] ?? 0,
+		total_tier_credits: res.data["total_tier_credits"] ?? 0,
+		total_prepaid_credits: res.data["total_prepaid_credits"] ?? 0,
+		daily,
+	};
+}
+
+export function useCreditsConsumptionQuery(rangeDate: ChartDate) {
+	return useQuery({
+		queryKey: ["credits-consumption", rangeDate.start_date, rangeDate.end_date],
+		queryFn: () => fetchCreditsConsumption(rangeDate),
+		staleTime: 5 * 60 * 1000,
+		gcTime: 10 * 60 * 1000,
+		placeholderData: (previousData) => previousData,
+		refetchOnMount: false,
+		refetchOnReconnect: false,
+	});
+}

--- a/src/hooks/useMessagesBySegmentQuery.ts
+++ b/src/hooks/useMessagesBySegmentQuery.ts
@@ -1,0 +1,27 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import { SegmentMessage, SegmentMessageSchema } from "@/types/subscriptions";
+import { ChartDate } from "@/types/dates";
+import env from "@/config/env";
+
+type Response = { total_messages: number; messages: SegmentMessage[] };
+
+async function fetchMessagesBySegment(rangeDate: ChartDate): Promise<Response> {
+	const res = await axios.get(
+		`${env.INFERENCE_BACKEND_URL}/stats/global/messages-by-segment?start_date=${rangeDate.start_date}&end_date=${rangeDate.end_date}`,
+	);
+	const messages: SegmentMessage[] = (res.data["messages"] ?? []).map((m: SegmentMessage) => SegmentMessageSchema.parse(m));
+	return { total_messages: res.data["total_messages"] ?? 0, messages };
+}
+
+export function useMessagesBySegmentQuery(rangeDate: ChartDate) {
+	return useQuery({
+		queryKey: ["messages-by-segment", rangeDate.start_date, rangeDate.end_date],
+		queryFn: () => fetchMessagesBySegment(rangeDate),
+		staleTime: 5 * 60 * 1000,
+		gcTime: 10 * 60 * 1000,
+		placeholderData: (previousData) => previousData,
+		refetchOnMount: false,
+		refetchOnReconnect: false,
+	});
+}

--- a/src/hooks/useSubscriptionsQuery.ts
+++ b/src/hooks/useSubscriptionsQuery.ts
@@ -3,14 +3,24 @@ import axios from "axios";
 import { TierSubscribers, TierSubscribersSchema } from "@/types/subscriptions";
 import env from "@/config/env";
 
-type Response = { subscribers_by_tier: TierSubscribers[]; total_paid_subscribers: number };
+type Response = {
+	subscribers_by_tier: TierSubscribers[];
+	total_paid_subscribers: number;
+	free_users: number;
+	anonymous_users: number;
+};
 
 async function fetchSubscriptions(): Promise<Response> {
 	const res = await axios.get(`${env.INFERENCE_BACKEND_URL}/stats/global/subscriptions`);
 	const subscribers_by_tier: TierSubscribers[] = (res.data["subscribers_by_tier"] ?? []).map((t: TierSubscribers) =>
 		TierSubscribersSchema.parse(t),
 	);
-	return { subscribers_by_tier, total_paid_subscribers: res.data["total_paid_subscribers"] ?? 0 };
+	return {
+		subscribers_by_tier,
+		total_paid_subscribers: res.data["total_paid_subscribers"] ?? 0,
+		free_users: res.data["free_users"] ?? 0,
+		anonymous_users: res.data["anonymous_users"] ?? 0,
+	};
 }
 
 export function useSubscriptionsQuery() {

--- a/src/hooks/useSubscriptionsQuery.ts
+++ b/src/hooks/useSubscriptionsQuery.ts
@@ -1,0 +1,25 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import { TierSubscribers, TierSubscribersSchema } from "@/types/subscriptions";
+import env from "@/config/env";
+
+type Response = { subscribers_by_tier: TierSubscribers[]; total_paid_subscribers: number };
+
+async function fetchSubscriptions(): Promise<Response> {
+	const res = await axios.get(`${env.INFERENCE_BACKEND_URL}/stats/global/subscriptions`);
+	const subscribers_by_tier: TierSubscribers[] = (res.data["subscribers_by_tier"] ?? []).map((t: TierSubscribers) =>
+		TierSubscribersSchema.parse(t),
+	);
+	return { subscribers_by_tier, total_paid_subscribers: res.data["total_paid_subscribers"] ?? 0 };
+}
+
+export function useSubscriptionsQuery() {
+	return useQuery({
+		queryKey: ["subscriptions-snapshot"],
+		queryFn: fetchSubscriptions,
+		staleTime: 5 * 60 * 1000,
+		gcTime: 10 * 60 * 1000,
+		refetchOnMount: false,
+		refetchOnReconnect: false,
+	});
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -10,6 +10,7 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as X402RouteImport } from './routes/x402'
+import { Route as SubscriptionsRouteImport } from './routes/subscriptions'
 import { Route as LiberclawRouteImport } from './routes/liberclaw'
 import { Route as CliRouteImport } from './routes/cli'
 import { Route as ChatRouteImport } from './routes/chat'
@@ -19,6 +20,11 @@ import { Route as IndexRouteImport } from './routes/index'
 const X402Route = X402RouteImport.update({
   id: '/x402',
   path: '/x402',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SubscriptionsRoute = SubscriptionsRouteImport.update({
+  id: '/subscriptions',
+  path: '/subscriptions',
   getParentRoute: () => rootRouteImport,
 } as any)
 const LiberclawRoute = LiberclawRouteImport.update({
@@ -53,6 +59,7 @@ export interface FileRoutesByFullPath {
   '/chat': typeof ChatRoute
   '/cli': typeof CliRoute
   '/liberclaw': typeof LiberclawRoute
+  '/subscriptions': typeof SubscriptionsRoute
   '/x402': typeof X402Route
 }
 export interface FileRoutesByTo {
@@ -61,6 +68,7 @@ export interface FileRoutesByTo {
   '/chat': typeof ChatRoute
   '/cli': typeof CliRoute
   '/liberclaw': typeof LiberclawRoute
+  '/subscriptions': typeof SubscriptionsRoute
   '/x402': typeof X402Route
 }
 export interface FileRoutesById {
@@ -70,14 +78,37 @@ export interface FileRoutesById {
   '/chat': typeof ChatRoute
   '/cli': typeof CliRoute
   '/liberclaw': typeof LiberclawRoute
+  '/subscriptions': typeof SubscriptionsRoute
   '/x402': typeof X402Route
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/api' | '/chat' | '/cli' | '/liberclaw' | '/x402'
+  fullPaths:
+    | '/'
+    | '/api'
+    | '/chat'
+    | '/cli'
+    | '/liberclaw'
+    | '/subscriptions'
+    | '/x402'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/api' | '/chat' | '/cli' | '/liberclaw' | '/x402'
-  id: '__root__' | '/' | '/api' | '/chat' | '/cli' | '/liberclaw' | '/x402'
+  to:
+    | '/'
+    | '/api'
+    | '/chat'
+    | '/cli'
+    | '/liberclaw'
+    | '/subscriptions'
+    | '/x402'
+  id:
+    | '__root__'
+    | '/'
+    | '/api'
+    | '/chat'
+    | '/cli'
+    | '/liberclaw'
+    | '/subscriptions'
+    | '/x402'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -86,6 +117,7 @@ export interface RootRouteChildren {
   ChatRoute: typeof ChatRoute
   CliRoute: typeof CliRoute
   LiberclawRoute: typeof LiberclawRoute
+  SubscriptionsRoute: typeof SubscriptionsRoute
   X402Route: typeof X402Route
 }
 
@@ -96,6 +128,13 @@ declare module '@tanstack/react-router' {
       path: '/x402'
       fullPath: '/x402'
       preLoaderRoute: typeof X402RouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/subscriptions': {
+      id: '/subscriptions'
+      path: '/subscriptions'
+      fullPath: '/subscriptions'
+      preLoaderRoute: typeof SubscriptionsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/liberclaw': {
@@ -142,6 +181,7 @@ const rootRouteChildren: RootRouteChildren = {
   ChatRoute: ChatRoute,
   CliRoute: CliRoute,
   LiberclawRoute: LiberclawRoute,
+  SubscriptionsRoute: SubscriptionsRoute,
   X402Route: X402Route,
 }
 export const routeTree = rootRouteImport

--- a/src/routes/chat.tsx
+++ b/src/routes/chat.tsx
@@ -1,7 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { InferenceAnalytics } from "@/components/InferenceAnalytics";
+import { MessagesBySegmentAnalytics } from "@/components/charts/MessagesBySegmentAnalytics";
 import { REQUEST_TYPES } from "@/config/requestTypes";
 
 export const Route = createFileRoute("/chat")({
-	component: () => <InferenceAnalytics type={REQUEST_TYPES.chat} />,
+	component: () => <InferenceAnalytics type={REQUEST_TYPES.chat} extra={<MessagesBySegmentAnalytics />} />,
 });

--- a/src/routes/subscriptions.tsx
+++ b/src/routes/subscriptions.tsx
@@ -1,0 +1,24 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { SubscribersByTier } from "@/components/charts/SubscribersByTier";
+import { MessagesBySegmentAnalytics } from "@/components/charts/MessagesBySegmentAnalytics";
+import { CreditsConsumptionAnalytics } from "@/components/charts/CreditsConsumptionAnalytics";
+
+export const Route = createFileRoute("/subscriptions")({
+	component: Subscriptions,
+});
+
+function Subscriptions() {
+	return (
+		<div className="container mx-auto px-4 py-6 space-y-6">
+			<div>
+				<h1 className="text-2xl font-bold">Subscriptions &amp; credits</h1>
+				<p className="text-sm text-muted-foreground mt-1">
+					Plan adoption, chat volume per segment, and credit consumption.
+				</p>
+			</div>
+			<SubscribersByTier />
+			<MessagesBySegmentAnalytics />
+			<CreditsConsumptionAnalytics />
+		</div>
+	);
+}

--- a/src/routes/subscriptions.tsx
+++ b/src/routes/subscriptions.tsx
@@ -1,6 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { SubscribersByTier } from "@/components/charts/SubscribersByTier";
-import { MessagesBySegmentAnalytics } from "@/components/charts/MessagesBySegmentAnalytics";
+import { UsersBySegment } from "@/components/charts/UsersBySegment";
 import { CreditsConsumptionAnalytics } from "@/components/charts/CreditsConsumptionAnalytics";
 
 export const Route = createFileRoute("/subscriptions")({
@@ -13,11 +12,10 @@ function Subscriptions() {
 			<div>
 				<h1 className="text-2xl font-bold">Subscriptions &amp; credits</h1>
 				<p className="text-sm text-muted-foreground mt-1">
-					Plan adoption, chat volume per segment, and credit consumption.
+					User base by segment and credit consumption across all usage (chat, API, CLI).
 				</p>
 			</div>
-			<SubscribersByTier />
-			<MessagesBySegmentAnalytics />
+			<UsersBySegment />
 			<CreditsConsumptionAnalytics />
 		</div>
 	);

--- a/src/types/subscriptions.ts
+++ b/src/types/subscriptions.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+export const SegmentMessageSchema = z.object({
+	date: z.string(),
+	segment: z.string(),
+	message_count: z.number(),
+});
+export type SegmentMessage = { date: string; segment: string; message_count: number };
+
+export const CreditsConsumptionDaySchema = z.object({
+	date: z.string(),
+	tier_credits: z.number(),
+	prepaid_credits: z.number(),
+});
+export type CreditsConsumptionDay = { date: string; tier_credits: number; prepaid_credits: number };
+
+export const TierSubscribersSchema = z.object({
+	tier: z.string(),
+	active_subscribers: z.number(),
+});
+export type TierSubscribers = { tier: string; active_subscribers: number };

--- a/src/utils/subscriptions.ts
+++ b/src/utils/subscriptions.ts
@@ -1,0 +1,66 @@
+import { ChartDate } from "@/types/dates";
+import { CreditsConsumptionDay, SegmentMessage } from "@/types/subscriptions";
+import { createEmptyResultByRangeDate } from "./dates";
+
+const SEGMENT_ORDER = ["anonymous", "free", "go", "plus", "max"];
+
+/** "free" -> "Free", "go" -> "Go", etc. — the chart series label. */
+export const segmentLabel = (segment: string): string => segment.charAt(0).toUpperCase() + segment.slice(1);
+
+const timeframeDays = (rangeDate: ChartDate): number => {
+	const start = new Date(rangeDate.start_date);
+	const end = new Date(rangeDate.end_date);
+	const diff = Math.abs(start.valueOf() - end.valueOf());
+	return Math.floor(diff / (1000 * 60 * 60 * 24)) + 1;
+};
+
+/** [{date, Anonymous, Free, Go, Plus, Max}] — one zero-filled row per day, message counts per segment. */
+export const groupMessagesBySegmentPerDay = (messages: SegmentMessage[], rangeDate: ChartDate) => {
+	const startDate = new Date(rangeDate.start_date);
+	const timeframe = timeframeDays(rangeDate);
+
+	const segments = Array.from(new Set(messages.map((m) => m.segment))).sort(
+		(a, b) => (SEGMENT_ORDER.indexOf(a) + 1 || 99) - (SEGMENT_ORDER.indexOf(b) + 1 || 99),
+	);
+	const initial: Record<string, number> = {};
+	segments.forEach((s) => {
+		initial[segmentLabel(s)] = 0;
+	});
+
+	const result = createEmptyResultByRangeDate<Record<string, Record<string, number>>>(
+		timeframe,
+		rangeDate,
+		startDate,
+		initial,
+	);
+
+	for (const m of messages) {
+		if (result[m.date]) result[m.date][segmentLabel(m.segment)] += m.message_count;
+	}
+
+	return Object.entries(result)
+		.map(([date, values]) => ({ date, ...values }))
+		.sort((a, b) => a.date.localeCompare(b.date));
+};
+
+/** [{date, "Tier-covered", "Prepaid"}] — daily credit consumption split by what paid for it. */
+export const groupCreditsConsumptionPerDay = (daily: CreditsConsumptionDay[], rangeDate: ChartDate) => {
+	const startDate = new Date(rangeDate.start_date);
+	const timeframe = timeframeDays(rangeDate);
+
+	const result = createEmptyResultByRangeDate<Record<string, Record<string, number>>>(timeframe, rangeDate, startDate, {
+		"Tier-covered": 0,
+		Prepaid: 0,
+	});
+
+	for (const d of daily) {
+		if (result[d.date]) {
+			result[d.date]["Tier-covered"] = d.tier_credits;
+			result[d.date]["Prepaid"] = d.prepaid_credits;
+		}
+	}
+
+	return Object.entries(result)
+		.map(([date, values]) => ({ date, ...values }))
+		.sort((a, b) => a.date.localeCompare(b.date));
+};


### PR DESCRIPTION
Brings the analytics dashboard up to date with the subscriptions/credits work in libertai-inference.

## New: Subscriptions page (Users & credits)
- **Users by segment** — anonymous (distinct logged-out chat IPs), registered free users, and active paid subscribers per tier. Subscriptions cover *all* usage (chat/API/CLI), so this is a user-base view, not a chat metric.
- **Credits consumption** — credits ($) consumed per day, split **tier-covered** (subscription entitlement) vs **prepaid** overflow. New metric (only tracked since metering).

## Chat page
- **Messages by plan** — chat messages/day per segment (anonymous, free, go/plus/max). Lives on the Chat page since it's chat usage. Sourced from `chat_requests` (the full chat history), so legacy and post-metering messages share **one continuous series** (backward compatible).

## Backend dependency
Needs new `/stats/global/*` endpoints added in libertai-inference (`feat/subscriptions-backend`): `messages-by-segment`, `credits-consumption`, `subscriptions` (now incl. `free_users`/`anonymous_users`). These are deployed on **beta** today; on prod they land when the subscriptions backend ships. Until then the prod dashboard's new charts will 404.

## Notes / caveats
- **Tier attribution is by *current* tier** — per-message historical tier isn't recorded, so a user's past messages show under the tier they're on today.
- **Anonymous users** are counted by distinct IP (anon_chat_usage) — soft/approximate (shared/NAT IPs, VPN rotation).
- Verified end-to-end against a local backend (real dev data): build + lint green; backend endpoints covered by tests.